### PR TITLE
Added reactify of package when using browserify.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.2",
   "description": "QR code for ReactJS",
   "main": "QRcode.js",
+  "browserify": {"transform": ["reactify"]},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Without it render always fails when building package with react-qrcode as dependency. <code>Browserify compile error: Parsing file <path>/node_modules/react-qrcode/QRcode.js: Unexpected token (89:4)</code>
